### PR TITLE
Wm count of teams

### DIFF
--- a/lib/team.rb
+++ b/lib/team.rb
@@ -28,5 +28,6 @@ class Team
 
   def self.count_of_teams
     @@teams.length
+    # do we need .uniq here?
   end
 end

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -25,4 +25,8 @@ class Team
     @stadium = team_info[:stadium]
     @link = team_info[:link]
   end
+
+  def self.count_of_teams
+    @@teams.length
+  end
 end

--- a/test/team_test.rb
+++ b/test/team_test.rb
@@ -20,4 +20,8 @@ class TeamTest < Minitest::Test
     assert_equal "/api/v1/teams/1", @team.first.link
   end
 
+  def test_it_can_calculate_total_teams
+    assert_equal 5, Team.count_of_teams
+  end
+
 end


### PR DESCRIPTION
Add count_of_teams method. Currently only counting the number of teams in the teams_csv. Are there different number of teams in each csv that I need to account for? Are there multiples of the same team within the team_csv?