### PR TITLE
Refactor all requires to be require_relative in order for rspec to run

### DIFF
--- a/test/game_team_test.rb
+++ b/test/game_team_test.rb
@@ -1,5 +1,5 @@
-require './lib/game_team'
 require_relative 'test_helper'
+require_relative '../lib/game_team'
 
 class GameTeamTest < Minitest::Test
 

--- a/test/game_test.rb
+++ b/test/game_test.rb
@@ -1,5 +1,5 @@
 require_relative 'test_helper'
-require './lib/game'
+require_relative '../lib/game'
 
 class GameTest < Minitest::Test
 

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -1,7 +1,5 @@
 require_relative 'test_helper'
-require 'minitest/autorun'
-require 'minitest/autorun'
-require './lib/stat_tracker'
+require_relative '../lib/stat_tracker'
 
 class StatTrackerTest < Minitest::Test
   def setup

--- a/test/team_test.rb
+++ b/test/team_test.rb
@@ -1,5 +1,5 @@
 require_relative 'test_helper'
-require './lib/team'
+require_relative '../lib/team'
 
 class TeamTest < Minitest::Test
 


### PR DESCRIPTION
spec harness requirements state that only require_relatives can be used in order to for spec to run. I installed the spec directory and refactored all requires to require_relative.