### PR TITLE
Add worst fans method to stat tracker class and passing tests

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -22,5 +22,33 @@ class StatTracker
   end
 
   def worst_fans
-  end
+     unique_teams = @game_teams.reduce({}) do |acc, game_team|
+       acc[game_team.team_id] = {away: 0, home: 0}
+       acc
+     end
+
+     @game_teams.each do |game_team|
+       if game_team.hoa == "away" && game_team.result == "WIN"
+         unique_teams[game_team.team_id][:away] += 1
+      elsif game_team.hoa == "home" && game_team.result == "WIN"
+        unique_teams[game_team.team_id][:home] += 1
+      end
+     end
+
+     worst_fans_are = unique_teams.find_all do |key, value|
+       value[:away] > value[:home]
+     end.to_h
+
+     worst_teams = worst_fans_are.to_h.keys
+
+     final = worst_teams.map do |team2|
+       @teams.find do |team1|
+          team2 == team1.team_id
+       end
+     end
+
+     finnalist = final.map do |team|
+       team.teamname
+     end
+   end
 end

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -26,7 +26,8 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_it_can_pull_all_teams_with_the_worst_fans
-    skip
+      stat_tracker = StatTracker.from_csv({games: './data/game.csv', teams: './data/team.csv', game_teams: './data/game_team.csv'})
+    assert_equal ["Houston Dynamo", "Utah Royals FC"], stat_tracker.worst_fans
     assert_equal [], @stat_tracker.worst_fans
   end
 end


### PR DESCRIPTION
* Add working worst fans method to stat tracker
* It was added to stat tracker because it needed to pull from game teams and teams to return the final names.
* It is an instance method
* Its tests do pass
* I test on the dummy file however there are no "worst teams" examples on dummy file so I did run a test with the whole data set as well.