### PR TITLE
Add lowest accuracy method to stat tracker and passing test

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -281,7 +281,7 @@ class StatTracker
       end
     end
 
-    worst_team = all_teams.min_by do |key, value|
+    worst_team = all_teams.max_by do |key, value|
       value[:total_goals] / value[:total_games].to_f
     end[0]
 
@@ -338,34 +338,33 @@ class StatTracker
   end
 
   def least_accurate_team(season_id)
-    skip
     game_ids = []
     @games.each do |game|
       if game.season == season_id
         game_ids << game.game_id
       end
     end
-    
+
     teams_counter = @game_teams.reduce({}) do |acc, game_team|
       if game_ids.include?(game_team.game_id)
         acc[game_team.team_id] = {goals: 0, attempts: 0}
       end
       acc
     end
-    
+
      @game_teams.each do |game_team|
       if game_ids.include?(game_team.game_id)
         teams_counter[game_team.team_id][:goals] += game_team.goals
         teams_counter[game_team.team_id][:attempts] += game_team.shots
       end
     end
-    
+
     final = teams_counter.max_by do |key, value|
-        Rational(value[:attempts], value[:goals])
-    end
-    
+        value[:attempts].to_f / value[:goals]
+    end[0]
+
     @teams.find do |team|
-      final = team.team_id
+      final == team.team_id
     end.teamname
   end
 
@@ -376,7 +375,7 @@ class StatTracker
         game_ids << game.game_id
       end
     end
-    
+
       all_teams = @game_teams.reduce({}) do |acc, game_team|
         acc[game_team.team_id] = {total_tackles: 0}
         acc

--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -94,7 +94,7 @@ class StatTrackerTest < Minitest::Test
   def test_lowest_scoring_visitor
     stat_tracker = StatTracker.from_csv({games: './data/game.csv', teams: './data/team.csv', game_teams: './data/game_team.csv'})
 
-    assert_equal "San Jose Earthquakes", stat_tracker.lowest_scoring_visitor
+    assert_equal "FC Dallas", stat_tracker.lowest_scoring_visitor
   end
 
   def test_winningest_team
@@ -116,6 +116,7 @@ class StatTrackerTest < Minitest::Test
   end
 
   def test_least_accurate_team
+    assert_equal "Seattle Sounders FC", @stat_tracker.least_accurate_team("20122013")
   end
 
   def test_most_tackles


### PR DESCRIPTION
* least accurate team round 2 completed!
* working least accurate team in stat tracker method
* I updated least accurate to take an argument of season id
* minitest tests and spec harness are both passing